### PR TITLE
torch.squeeze causes an error for valid batch size 1

### DIFF
--- a/models/hovernet/run_desc.py
+++ b/models/hovernet/run_desc.py
@@ -35,8 +35,8 @@ def train_step(batch_data, run_info):
     imgs = imgs.permute(0, 3, 1, 2).contiguous()
 
     # HWC
-    true_np = torch.squeeze(true_np).to("cuda").type(torch.int64)
-    true_hv = torch.squeeze(true_hv).to("cuda").type(torch.float32)
+    true_np = true_np.to("cuda").type(torch.int64)
+    true_hv = true_hv.to("cuda").type(torch.float32)
 
     true_np_onehot = (F.one_hot(true_np, num_classes=2)).type(torch.float32)
     true_dict = {


### PR DESCRIPTION
Fixes the following error that occurs if _{size-of-val-set} mod {size-of-val-batch-size} = 1_, because in this case `torch.squeeze` removes the dimension corresponding to the current batch size, which is 1 for the last batch:

```
Traceback (most recent call last):
  File "run_train.py", line 305, in <module>
    trainer.run()
  File "run_train.py", line 289, in run
    phase_info, engine_opt, save_path, prev_log_dir=prev_save_path
  File "run_train.py", line 265, in run_once
    main_runner.run(opt["nr_epochs"])
  File "/home/user/Repos/hover_net/run_utils/engine.py", line 197, in run
    self.__trigger_events(Events.EPOCH_COMPLETED)
  File "/home/user/Repos/hover_net/run_utils/engine.py", line 123, in __trigger_events
    callback.run(self.state, event)
  File "/home/user/Repos/hover_net/run_utils/callbacks/base.py", line 70, in run
    chained=True, nr_epoch=self.nr_epoch, shared_state=state
  File "/home/user/Repos/hover_net/run_utils/engine.py", line 197, in run
    self.__trigger_events(Events.EPOCH_COMPLETED)
  File "/home/user/Repos/hover_net/run_utils/engine.py", line 123, in __trigger_events
    callback.run(self.state, event)
  File "/home/user/Repos/hover_net/run_utils/callbacks/base.py", line 213, in run
    track_dict = self.proc_func(raw_data)
  File "/home/user/Repos/hover_net/models/hovernet/opt.py", line 135, in <lambda>
    lambda a: proc_valid_step_output(a, nr_types=nr_type)
  File "/home/user/Repos/hover_net/models/hovernet/run_desc.py", line 283, in proc_valid_step_output
    patch_prob_np = prob_np[idx]
IndexError: list index out of range
```
