### PR TITLE
fix bug that mrxs file may cause

### DIFF
--- a/infer/wsi.py
+++ b/infer/wsi.py
@@ -732,6 +732,8 @@ class InferManager(base.InferManager):
         wsi_path_list = glob.glob(self.input_dir + "/*")
         wsi_path_list.sort()  # ensure ordering
         for wsi_path in wsi_path_list[:]:
+            if os.path.isdir(wsi_path):
+                continue
             wsi_base_name = pathlib.Path(wsi_path).stem
             msk_path = "%s/%s.png" % (self.input_mask_dir, wsi_base_name)
             if self.save_thumb or self.save_mask:


### PR DESCRIPTION
A mrxs format whole slide file contains a folder with various .dat files and a .mrxs file. During running run_infer.py, the program may handle the folder file as well, it will cause an error as OpenSlide can only read the .mrxs file instead of its folder. 
This PR fixes this problem by skipping the folder to let the wsi.py only read the supported .mrxs file itself while having no conflict with other formats of WSIs.